### PR TITLE
Browser client event management improvement

### DIFF
--- a/app/src/hooks/useEvents.ts
+++ b/app/src/hooks/useEvents.ts
@@ -3,10 +3,26 @@ import BrowserEvents from "../utils/browserEvents";
 
 type BrowserMessageCallback = (...args: any[]) => void;
 
-function useEvents(channel: string, callback: BrowserMessageCallback) {
+interface UseEventsInterface {
+  channel: string;
+  broadcast?: boolean;
+  payload?: any;
+  callback: BrowserMessageCallback;
+}
+
+function useEvents({
+  channel,
+  callback,
+  broadcast,
+  payload,
+}: UseEventsInterface) {
   const listener: BrowserMessageCallback = (...args) => {
     callback(...args);
   };
+
+  if (broadcast) {
+    BrowserEvents.send(channel, payload);
+  }
 
   BrowserEvents.on(channel, listener);
 

--- a/app/src/modules/webview-panels/components/ViewPanel.tsx
+++ b/app/src/modules/webview-panels/components/ViewPanel.tsx
@@ -11,12 +11,18 @@ function ViewPanel(props: { panel?: PanelInterface }) {
   const [widthPercent, setWidthPercent] = createSignal("100%");
   const [isFocusedPanel, setIsFocusedPanel] = createSignal(false);
 
-  useEvents("baseWindow:toogleToolbar", () => {
-    ToolbarState.toggleToolbar();
+  useEvents({
+    channel: "baseWindow:toogleToolbar",
+    callback: () => {
+      ToolbarState.toggleToolbar();
+    },
   });
 
-  useEvents("baseWindow:toogleSidebar", () => {
-    SidebarState.toggleSidebar();
+  useEvents({
+    channel: "baseWindow:toogleSidebar",
+    callback: () => {
+      SidebarState.toggleSidebar();
+    },
   });
 
   const updateBounds = () => {


### PR DESCRIPTION
- Improved event emitter event `useEvents` so that it can broadcast and listen to events.
- Modified existing code that was using the hook in client.